### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides tools for interacting with Trello boards. This server enables seamless integration with Trello's API while handling rate limiting, type safety, and error handling automatically.
 
+<a href="https://glama.ai/mcp/servers/@diegofornalha/mcp-server-trello">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@diegofornalha/mcp-server-trello/badge" alt="Server Trello MCP server" />
+</a>
+
 ## Features
 
 - **Full Trello Board Integration**: Interact with cards, lists, and board activities
@@ -104,8 +108,8 @@ Update an existing card's details.
     cardId: string,       // ID of the card to update
     name?: string,        // Optional: New name for the card
     description?: string, // Optional: New description
-    dueDate?: string,    // Optional: New due date (ISO 8601 format)
-    labels?: string[]    // Optional: New array of label IDs
+    dueDate?: string,     // Optional: New due date
+    labels?: string[]     // Optional: New array of label IDs
   }
 }
 ```


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Trello](https://glama.ai/mcp/servers/@diegofornalha/mcp-server-trello) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@diegofornalha/mcp-server-trello">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@diegofornalha/mcp-server-trello/badge" alt="Server Trello MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.